### PR TITLE
MQ: fix compiler warnings 

### DIFF
--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2631,9 +2631,9 @@ void SensorMCP9808::onInterrupt() {
  */
 #if MODULE_MQ == 1
 
-static float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
-static float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
-static float SensorMQ::_default_SmokeCurve[3] = {2.3,0.53,-0.44};
+float SensorMQ::_default_LPGCurve[3] = {2.3,0.21,-0.47};
+float SensorMQ::_default_COCurve[3] = {2.3,0.72,-0.34};
+float SensorMQ::_default_SmokeCurve[3] = {2.3,0.53,-0.44};
 
 SensorMQ::SensorMQ(const NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
   _name = "MQ";


### PR DESCRIPTION
Static class member definitions don't need a static keyword, only the declaration inside the class needs it...