### PR TITLE
MH-Z19: Make the TX and RX pins configurable in the constructor

### DIFF
--- a/NodeManagerLibrary.h
+++ b/NodeManagerLibrary.h
@@ -1146,7 +1146,7 @@ class SensorMQ: public Sensor {
 #if MODULE_MHZ19 == 1
 class SensorMHZ19: public Sensor {
   public:
-    SensorMHZ19(const NodeManager& node_manager, int pin);
+    SensorMHZ19(const NodeManager& node_manager, int rxpin, int txpin);
     // define what to do at each stage of the sketch
     void onBefore();
     void onSetup();

--- a/NodeManagerLibrary.ino
+++ b/NodeManagerLibrary.ino
@@ -2790,10 +2790,10 @@ int SensorMQ::_MQGetPercentage(float rs_ro_ratio, float *pcurve) {
 */
 #if MODULE_MHZ19 == 1
 // contructor
-SensorMHZ19::SensorMHZ19(const NodeManager& node_manager, int pin): Sensor(node_manager, pin) {
+SensorMHZ19::SensorMHZ19(const NodeManager& node_manager, int rxpin, int txpin): Sensor(node_manager, rxpin) {
   _name = "MHZ19";
-  _rx_pin = pin;
-  _tx_pin = pin+1;
+  _rx_pin = rxpin;
+  _tx_pin = txpin;
 }
 
 // what to do during before


### PR DESCRIPTION
As the setRxTx method was removed during the update to the latest architecture change, this adds the RX and TX pin definition directly to the constructure. The new architecture allows arbitrary function signatures for the constructor, so we can pass both pins directly in the constructor (cannot be changed later on, anyway).